### PR TITLE
Adds StandardCollector for custom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are two ways to add further metrics. One is extending the [BaseCollector](
 
 When extending from the `BaseCollector` the client has to take care of edge-cases such as the host not answering. The `StandardCollector` takes care of these things and requires solely the logic for creating the Prometheus metrics from query results.
 
-If you want to contribute additional metrics take the [ApicCoopDbCollector](collectors/apiccoobdb.py) as an Example.
+If you want to contribute additional metrics take the [ApicCoopDbCollector](collectors/apiccoopdb.py) as an Example.
 Here the metrics are defined as a List of `CustomMetric` objects. Each of these objects contains the name of the metric, the query required to fetch the data from the APIC hosts and a method which processes this data. This method is responsible for creating the Prometheus metric from the fetched data.
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
-# apic-exporter
-prometheus exporter written in python3 to get custom apic metrics
+# APIC Exporter
+
+A Prometheus exporter written in Python3 to retrieve custom metrics from Cisco APICs.
+
+## Adding further metrics
+
+There are two ways to add further metrics. One is extending the [BaseCollector](BaseCollector.py) and the other is extending the [StandardCollector](StandardCollector.py).
+
+When extending from the `BaseCollector` the client has to take care of edge-cases such as the host not answering. The `StandardCollector` takes care of these things and requires solely the logic for creating the Prometheus metrics from query results.
+
+If you want to contribute additional metrics take the [ApicCoopDbCollector](collectors/apiccoobdb.py) as an Example.
+Here the metrics are defined as a List of `CustomMetric` objects. Each of these objects contains the name of the metric, the query required to fetch the data from the APIC hosts and a method which processes this data. This method is responsible for creating the Prometheus metric from the fetched data.
 
 ## Docker
 
-Build the Docker image locally with `make build`. 
- 
+Build the Docker image locally with `make build`.
+
 And test with `docker run -p 9102:9102 -v ~/Developer/git/apic-exporter/apic-config-sample.yaml:/config.yaml apic-exporter:latest -c /config.yaml`
 
 ## Further Readings

--- a/StandardCollector.py
+++ b/StandardCollector.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Callable, Dict, List
+from dataclasses import dataclass
+from prometheus_client.core import Summary
+from prometheus_client.metrics_core import Metric
+import BaseCollector
+
+LOG = logging.getLogger('apic_exporter.exporter')
+
+
+@dataclass
+class CustomMetric:
+    name: str
+    query: str
+    process_data: Callable[[str, Dict], List[Metric]]
+
+
+class StandardCollector(BaseCollector.BaseCollector):
+    def __init__(self, name: str, config: Dict, metrics: List[CustomMetric]):
+        super().__init__(config)
+        self.__metrics = metrics
+        self.__metric_counter = 0
+        self.__name = name
+        self.__request_time = Summary('{name}_processing_seconds'.format(name=self.__name),
+                                      'Time spend processing request')
+
+    def collect(self):
+        self.__metric_counter = 0
+        with self.__request_time.time():
+            LOG.debug('Collecting %s metrics ...', self.__name)
+            for metric in self.__metrics:
+                for host in self.hosts:
+                    fetched_data = self.query_host(host, metric.query)
+                    if fetched_data is None:
+                        LOG.warning("Skipping apic host %s, %s did not return anything", host, self.__query)
+                        continue
+                    metric_family = metric.process_data(host, fetched_data)
+                    if metric_family is None:
+                        continue
+                    self.__metric_counter += len(metric_family.samples)
+                    yield metric_family
+                    break  # all hosts produce the same metrics, hence querying one is sufficient
+            LOG.info('Collected %s %s metrics', self.__metric_counter, self.__name)

--- a/collectors/apiccoopdb.py
+++ b/collectors/apiccoopdb.py
@@ -1,62 +1,40 @@
+from StandardCollector import StandardCollector, CustomMetric
 import logging
-import BaseCollector
-from prometheus_client.core import GaugeMetricFamily, Summary
+from prometheus_client.core import GaugeMetricFamily
 from typing import List, Dict
 
 LOG = logging.getLogger('apic_exporter.exporter')
-REQUEST_TIME = Summary('apic_coop_processing_seconds',
-                       'Time spent processing request')
 
 
-class ApicCoopDbCollector(BaseCollector.BaseCollector):
+class ApicCoopDbCollector(StandardCollector):
 
     def __init__(self, config: Dict):
-        super().__init__(config)
-        self.__metric_counter = 0
+        metrics = [CustomMetric(
+          name='network_apic_coop_records_total',
+          query='/api/node/class/fabricNode.json?query-target-filter=eq(fabricNode.role,"spine")',
+          process_data=self.collect_apic_coop_db_size
+        )]
+        super().__init__('apic_coop', config, metrics)
 
     def describe(self):
         yield GaugeMetricFamily('network_apic_coop_records_total',
                                 'APIC COOP DB entries')
 
-    @REQUEST_TIME.time()
-    def collect(self):
-        LOG.debug('Collecting APIC coop db metrics ...')
-
-        self.__metric_counter = 0
-
-        yield self.collect_apic_coop_db_size()
-
-        LOG.info('Collected %s APIC COOP DB metrics', self.__metric_counter)
-
-    def collect_apic_coop_db_size(self) -> List[GaugeMetricFamily]:
+    def collect_apic_coop_db_size(self, host: str, data: Dict) -> List[GaugeMetricFamily]:
         """Collect the number of entries in the coop db for all spines"""
         g_coop_db = GaugeMetricFamily('network_apic_coop_records_total',
                                       'APIC COOP DB entries',
                                       labels=['apicHost', 'spineDn'])
-
-        query_spines = '/api/node/class/fabricNode.json?query-target-filter=eq(fabricNode.role,"spine")'
-        for host in self.hosts:
-            fetched_data = self.connection.getRequest(host, query_spines)
-            if not self.connection.isDataValid(fetched_data):
-                LOG.warning(
-                    "Skipping apic host %s, %s did not return anything", host,
-                    query_spines)
-                continue
-            for spine in fetched_data['imdata']:
-                spine_attributes = spine['fabricNode']['attributes']
-                query_coop_count = '/api/node/mo/' + spine_attributes[
-                    'dn'] + '/sys/coop/inst/dom-overlay-1.json?query-target=subtree&target-subtree-class=coopEpRec&rsp-subtree-include=count'
-                fetched_data = self.connection.getRequest(
-                    host, query_coop_count)
-                if not self.connection.isDataValid(fetched_data):
-                    LOG.warning(
-                        "Skipping apic host %s, %s did not return anything for spine %s",
-                        host, query_coop_count, spine_attributes['dn'])
-                    continue
-                fetched_count = fetched_data['imdata'][0]['moCount']['attributes']['count']
-
-                g_coop_db.add_metric(labels=[host, spine_attributes['dn']],
-                                     value=fetched_count)
-                self.__metric_counter += 1
-            break  # Each host produces the same metrics.
+        for spine in data['imdata']:
+            spine_attributes = spine['fabricNode']['attributes']
+            query_coop_count = '/api/node/mo/' + \
+                               spine_attributes['dn'] + \
+                               '/sys/coop/inst/dom-overlay-1.json' + \
+                               '?query-target=subtree&target-subtree-class=coopEpRec&rsp-subtree-include=count'
+            fetched_data = self.query_host(host, query_coop_count)
+            if fetched_data is None:
+                return None
+            fetched_count = fetched_data['imdata'][0]['moCount']['attributes']['count']
+            g_coop_db.add_metric(labels=[host, spine_attributes['dn']],
+                                 value=fetched_count)
         return g_coop_db

--- a/collectors/apiceqpt.py
+++ b/collectors/apiceqpt.py
@@ -34,11 +34,12 @@ class ApicEquipmentCollector(BaseCollector.BaseCollector):
         for host in self.hosts:
             query = '/api/node/class/eqptFlash.json' + \
                     '?rsp-subtree=full&query-target-filter=wcard(eqptFlash.model,\"Micron_M500IT\")'
-            fetched_data = self.connection.getRequest(host, query, TIMEOUT)
-            if not self.connection.isDataValid(fetched_data):
+            fetched_data = self.query_host(host, query, TIMEOUT)
+            if fetched_data is None:
                 LOG.warning(
                     "Skipping apic host %s, %s did not return anything", host,
                     query)
+                continue
 
             # get a list of all flash devices NOT in read-write mode
             flashes = [eqpt_template(type=d['eqptFlash']['attributes']['type'],

--- a/collectors/apichealth.py
+++ b/collectors/apichealth.py
@@ -38,8 +38,8 @@ class ApicHealthCollector(BaseCollector.BaseCollector):
         for host in self.hosts:
             query = '/api/node/class/topSystem.json?query-target-filter=eq(topSystem.oobMgmtAddr,\"' + \
                 host + '\")'
-            fetched_data = self.connection.getRequest(host, query, TIMEOUT)
-            if not self.connection.isDataValid(fetched_data):
+            fetched_data = self.query_host(host, query, TIMEOUT)
+            if fetched_data is None:
                 LOG.warning(
                     "Skipping apic host %s, %s did not return anything", host,
                     query)
@@ -66,8 +66,8 @@ class ApicHealthCollector(BaseCollector.BaseCollector):
 
         query = '/api/node/class/procEntity.json?'
         for host in self.hosts:
-            fetched_data = self.connection.getRequest(host, query)
-            if not self.connection.isDataValid(fetched_data):
+            fetched_data = self.query_host(host, query)
+            if fetched_data is None:
                 LOG.warning(
                     "Skipping apic host %s, %s did not return anything", host,
                     query)

--- a/collectors/apicinterfaces.py
+++ b/collectors/apicinterfaces.py
@@ -26,8 +26,8 @@ class ApicInterfacesCollector(BaseCollector.BaseCollector):
         # query only reset counters > 0
         query = '/api/node/class/ethpmPhysIf.json?query-target-filter=gt(ethpmPhysIf.resetCtr,"0")'
         for host in self.hosts:
-            fetched_data = self.connection.getRequest(host, query)
-            if not self.connection.isDataValid(fetched_data):
+            fetched_data = self.query_host(host, query)
+            if fetched_data is None:
                 LOG.warning(
                     "Skipping apic host %s, %s did not return anything", host,
                     query)

--- a/collectors/apicips.py
+++ b/collectors/apicips.py
@@ -27,11 +27,8 @@ class ApicIPsCollector(BaseCollector.BaseCollector):
         query = '/api/node/class/fvIp.json' + \
                 '?rsp-subtree=full&rsp-subtree-class=fvReportingNode&query-target-filter=and(ne(fvIp.debugMACMessage,""))'
         for host in self.hosts:
-            fetched_data = self.connection.getRequest(host, query)
-            if not self.connection.isDataValid(fetched_data):
-                LOG.warning(
-                    "Skipping apic host %s, %s did not return anything", host,
-                    query)
+            fetched_data = self.query_host(host, query)
+            if fetched_data is None:
                 continue
 
             if len(fetched_data['imdata']) == 0:

--- a/collectors/apicmcpfault.py
+++ b/collectors/apicmcpfault.py
@@ -25,8 +25,9 @@ class ApicMCPCollector(BaseCollector.BaseCollector):
         metric_counter = 0
         query = "/api/node/class/faultInst.json" + \
                 "?query-target-filter=or(eq(faultInst.code,\"F2533\"),eq(faultInst.code,\"F2534\"))"
-            fetched_data = self.connection.getRequest(host, query)
-            if not self.connection.isDataValid(fetched_data):
+        for host in self.hosts:
+            fetched_data = self.query_host(host, query)
+            if fetched_data is None:
                 LOG.warning(
                     "Skipping apic host %s, %s did not return anything", host, query)
                 continue

--- a/collectors/apicprocesses.py
+++ b/collectors/apicprocesses.py
@@ -42,8 +42,8 @@ class ApicProcessesCollector(BaseCollector.BaseCollector):
         metric_counter = 0
         query = '/api/node/class/fabricNode.json?'
         for host in self.hosts:
-            fetched_data = self.connection.getRequest(host, query)
-            if not self.connection.isDataValid(fetched_data):
+            fetched_data = self.query_host(host, query)
+            if fetched_data is None:
                 LOG.warning(
                     "Skipping apic host %s, %s did not return anything", host,
                     query)
@@ -57,8 +57,8 @@ class ApicProcessesCollector(BaseCollector.BaseCollector):
                           node_role)
 
                 proc_query = '/api/node/class/' + node_dn + '/procProc.json?query-target-filter=eq(procProc.name,"nfm")'
-                proc_data = self.connection.getRequest(host, proc_query)
-                if not self.connection.isDataValid(proc_data):
+                proc_data = self.query_host(host, proc_query)
+                if fetched_data is None:
                     LOG.info("Apic host %s node %s has no nfm process", host,
                              node_dn)
                     continue
@@ -70,8 +70,8 @@ class ApicProcessesCollector(BaseCollector.BaseCollector):
                     proc_name = proc_data['imdata'][0]['procProc'][
                         'attributes']['name']
                     mem_query = '/api/node/mo/' + proc_dn + '/HDprocProcMem5min-0.json'
-                    mem_data = self.connection.getRequest(host, mem_query)
-                    if not self.connection.isDataValid(mem_data):
+                    mem_data = self.query_host(host, mem_query)
+                    if mem_data is None:
                         LOG.info(
                             "Apic host %s node %s process %s has no memory data",
                             host, node_dn, proc_dn)

--- a/collectors/apicspineport.py
+++ b/collectors/apicspineport.py
@@ -45,8 +45,9 @@ class ApicSpinePortsCollector(BaseCollector.BaseCollector):
         query_url = '/api/node/class/fabricNode.json?' + \
                     '&query-target-filter=eq(fabricNode.role,"spine")&order-by=fabricNode.id|asc'
         for host in self.hosts:
-            output = self.connection.getRequest(host, query_url)
-            # output  = json.loads(query.text)
+            output = self.query_host(host, query_url)
+            if output is None:
+                continue
             count = output['totalCount']
             spine_dn_list = []
             for x in range(0, int(count)):
@@ -56,6 +57,9 @@ class ApicSpinePortsCollector(BaseCollector.BaseCollector):
             # fetch physcal port from each spine
             for dn in spine_dn_list:
                 query_url = '/api/node/mo/' + dn + '/sys.json?rsp-subtree=full&rsp-subtree-class=ethpmPhysIf'
+                output = self.query_host(host, query_url)
+                if output is None:
+                    continue
                 free_port_count = 0
                 used_port_count = 0
                 down_port_count = 0


### PR DESCRIPTION
StandardCollector reduces the amount of code to write for
new metrics.
Only code for creating Prometheus metrics is required.
Logic for host not responding etc is handled by the StandardCollector.
See apiccoopdb.py as an Example
