### PR TITLE
Fixes errors regarding unavailable hosts

### DIFF
--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -26,6 +26,8 @@ class BaseCollector(ABC):
         fetched_data = (self.__connection.getRequest(host, query, timeout)
                         if timeout is not None
                         else self.__connection.getRequest(host, query))
+        if fetched_data is None:
+            return None
         if not self.__connection.isDataValid(fetched_data):
             LOG.warning(
                 "Apic host %s, %s did not return anything", host,

--- a/collectors/apichealth.py
+++ b/collectors/apichealth.py
@@ -40,9 +40,6 @@ class ApicHealthCollector(BaseCollector.BaseCollector):
                 host + '\")'
             fetched_data = self.query_host(host, query, TIMEOUT)
             if fetched_data is None:
-                LOG.warning(
-                    "Skipping apic host %s, %s did not return anything", host,
-                    query)
                 g_access.add_metric(labels=[host], value=0)
             else:
                 g_access.add_metric(labels=[host], value=1)

--- a/collectors/apicprocesses.py
+++ b/collectors/apicprocesses.py
@@ -58,7 +58,7 @@ class ApicProcessesCollector(BaseCollector.BaseCollector):
 
                 proc_query = '/api/node/class/' + node_dn + '/procProc.json?query-target-filter=eq(procProc.name,"nfm")'
                 proc_data = self.query_host(host, proc_query)
-                if fetched_data is None:
+                if proc_data is None:
                     LOG.info("Apic host %s node %s has no nfm process", host,
                              node_dn)
                     continue

--- a/modules/Connection.py
+++ b/modules/Connection.py
@@ -85,6 +85,9 @@ class SessionPool(object):
             session.cookies.clear_session_cookies()
             session.cookies = cookies.cookiejar_from_dict(
                 cookie_dict={"APIC-cookie": cookie}, cookiejar=session.cookies)
+            available = True
+        else:
+            available = False
 
         self.__sessions[host] = session_tuple(session, available)
         return session
@@ -110,11 +113,9 @@ class SessionPool(object):
                 requests.exceptions.ReadTimeout, TimeoutError):
             LOG.error("Connection with host %s timed out after %s sec", host,
                       COOKIE_TIMEOUT)
-            self.set_session_unavailable(host)
             return None
         except (requests.exceptions.ConnectionError, ConnectionError) as e:
             LOG.error("Cannot connect to %s: %s", url, e)
-            self.set_session_unavailable(host)
             return None
 
         cookie = None


### PR DESCRIPTION
- Fixes a wrong None check for proc_data in `apicprocesses`, which would lead to an exception
- Fixes error that sessions were not being set as unavailable if the cookie could not be retrieved 
- Removes redundant apic health logs for unavailable host

 Before:
> ```
> [2021-11-15 13:34:02,042] [INFO] Skipped unavailable host xyz query /api/node/class/topSystem.json?query-target-filter=eq(topSystem.oobMgmtAddr,"xyz")
> [2021-11-15 13:34:02,043] [WARNING] Apic host xyz, /api/node/class/topSystem.json?query-target-filter=eq(topSystem.oobMgmtAddr,"xyz") did not return anything
> [2021-11-15 13:34:02,043] [WARNING] Skipping apic host xyz, /api/node/class/topSystem.json?query-target-filter=eq(topSystem.oobMgmtAddr,"xyz") did not return anything
> ```

After:

> [2021-11-15 14:05:31,706] [INFO] Skipped unavailable host xyz query /api/node/class/topSystem.json?query-target-filter=eq(topSystem.oobMgmtAddr,"xyz")
